### PR TITLE
Fix lspci parser

### DIFF
--- a/pypci/__init__.py
+++ b/pypci/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 
 from .pypci import lspci

--- a/pypci/__init__.py
+++ b/pypci/__init__.py
@@ -1,10 +1,8 @@
 
 __version__ = '0.1.3'
 
-try:
-    from .pypci import lspci
-    from .pypci import read
-    from .pypci import write
 
-except:
-    pass
+from .pypci import lspci
+from .pypci import read
+from .pypci import write
+

--- a/pypci/pypci.py
+++ b/pypci/pypci.py
@@ -123,18 +123,24 @@ def parse_lspci_output(output_txt):
         return size
     
     def get_io_addr(line):
-        if line.find('bridge') != -1:
-            line = line.split('-')[0]
-            return int(line.split()[-1], 16)
-        
-        return int(line.split()[3], 16)
+        try:
+            if line.find('bridge') != -1:
+                line = line.split('-')[0]
+                return int(line.split()[-1], 16)
+            
+            return int(line.split()[3], 16)
+        except ValueError:
+            return
     
     def get_mem_addr(line):
-        if line.find('bridge') != -1:
-            line = line.split('-')[0]
-            return int(line.split()[-1], 16)
-        
-        return int(line.split()[2], 16)
+        try:
+            if line.find('bridge') != -1:
+                line = line.split('-')[0]
+                return int(line.split()[-1], 16)
+            
+            return int(line.split()[2], 16)
+        except ValueError:
+            return
     
     bar_list = []
     dump = b''


### PR DESCRIPTION
## What this is

If the output of `lspci` contains `[disabled]` devices, the parser fails.
This pull request fixes the problem, and also, prevents the package import from failing silently.

## Tested on

- Ubuntu 18.04 with Interface PCI board connected
  - Default Python environment
  - Via SSH
  - On Ubuntu 22.04 docker image
    - Default Python environment
    - From ROS 2 program
- Ubuntu 20.04 virtual machine
  - Default Python environment
- Ubuntu 22.04
  - Default Python environment