### PR TITLE
Fix: Added support for Gigabyte(G) in the `get_register_size` function.

### DIFF
--- a/pypci/pypci.py
+++ b/pypci/pypci.py
@@ -116,6 +116,8 @@ def parse_lspci_output(output_txt):
             size = int(size_str[:-1]) * 1024
         elif size_str.endswith('M'):
             size = int(size_str[:-1]) * 1024 * 1024
+        elif size_str.endswith('G'):
+            size = int(size_str[:-1]) * 1024 * 1024 * 1024
         else:
             size = int(size_str)
             pass


### PR DESCRIPTION
I had a problem with my PCIe design on a D50DNP machine which can assign memory in the Gigabytes(G) and the `lspci` parsing errored out. I have added a small snippet to handle it.